### PR TITLE
Disable inspector port in Cloudflare plugin configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,12 @@ import react from "@vitejs/plugin-react";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
 export default defineConfig({
-  plugins: [react(), cloudflare()],
+  plugins: [
+    react(),
+    cloudflare({
+      inspectorPort: false,
+    }),
+  ],
   css: {
     devSourcemap: true,
   },


### PR DESCRIPTION
## Summary
- Configured the Cloudflare Vite plugin to disable the inspector port
- Updated `vite.config.ts` to set `inspectorPort: false` for improved development setup

## Changes

### Vite Configuration
- Modified `vite.config.ts`:
  - Added `inspectorPort: false` to the Cloudflare plugin options
  - This prevents the inspector port from being opened during development

## Test plan
- [x] Started development server and confirmed no inspector port is opened
- [x] Verified that the React plugin and other settings remain unaffected
- [x] Ensured no errors are introduced by the updated Cloudflare plugin setup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9493837c-9b90-448d-b67e-a78985304056